### PR TITLE
BC-25 - Moved the form control interfaces from the headless library, so they can be used in all libraries.

### DIFF
--- a/src/custom-types/form-control.interface.ts
+++ b/src/custom-types/form-control.interface.ts
@@ -1,0 +1,22 @@
+import React from 'react';
+import { JsonData } from './json-data.ts';
+
+export interface FormInputControl<V = unknown, C = undefined> {
+  id?: string;
+  label?: string;
+  name?: string;
+  value?: V;
+  readOnly?: boolean;
+  placeholder?: string;
+  onFocus?: (event: FocusEvent) => void;
+  onBlur?: (event: FocusEvent) => void;
+  onInput?: (event: React.FormEvent) => void;
+  onChange?: (value?: C extends undefined ? V : C) => void;
+  className?: string;
+}
+
+export interface FormInputControlData<V = unknown, C = undefined> extends FormInputControl<V, C> {
+  textField: string;
+  valueField: string;
+  data?: JsonData;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { useStateRef } from './hooks/use-state-ref.ts';
 
 // types
 import { DebouncedFunction } from './functions/debounce/debounce.ts';
+import { FormInputControl, FormInputControlData } from './custom-types/form-control.interface.ts';
 import { InitialState } from './hooks/use-state-initial.ts';
 import { JsonItem, JsonData } from './custom-types/json-data.ts';
 import { MakeOptional } from './custom-types/make-optional.ts';
@@ -32,6 +33,8 @@ export {
 
 export type {
   DebouncedFunction,
+  FormInputControl,
+  FormInputControlData,
   InitialState,
   JsonData,
   JsonItem,


### PR DESCRIPTION
Moved the `FormInputControl` and `FormInputControlData` interfaces from the headless library.