### PR TITLE
BC-28 - useEvent Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Created a `useEvent` hook that will maintain a stable function that will always have the latest version of any state variables or component properties.
+
 ## [0.1.13] - 2025-06-13
 
 ## Added

--- a/src/hooks/use-event.ts
+++ b/src/hooks/use-event.ts
@@ -1,0 +1,39 @@
+import { useInsertionEffect, useRef } from 'react';
+
+/**
+ * The callback can be a function of any number of arguments.
+ */
+type UnknownFunction = (...args: Array<never>) => never;
+
+const useEventPreMountCallbackError = () => {
+  throw new Error('useEvent should not be called before the component is mounted');
+};
+
+/**
+ * Creates a stable function that will always contain the latest state or property values and doesn't require the use of
+ * a dependency array. This is currently submitted as a React RFC and is explained here
+ * https://github.com/reactjs/rfcs/blob/useevent/text/0000-useevent.md.
+ * @param callback - The actual function to run.
+ */
+const useEvent = <T extends UnknownFunction>(callback: T) => {
+  // maintains the actual code to run...this is updated on every render
+  const latestCallback = useRef<T>(useEventPreMountCallbackError as never);
+  useInsertionEffect(() => {
+    latestCallback.current = callback;
+  }, [callback]);
+
+  // creates the stable function that does not change on each render
+  const stableCallback = useRef<T>(null as never);
+  if (!stableCallback.current) {
+    stableCallback.current = function (this: never) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      // eslint-disable-next-line prefer-rest-params
+      return latestCallback.current?.apply(this, arguments);
+    } as T;
+  }
+
+  return stableCallback.current;
+};
+
+export { useEvent };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import deepEquals from 'fast-deep-equal';
 import { forceAssert } from './functions/common.ts';
 import { useDeepMemo } from './hooks/use-deep-memo.ts';
 import { useDeepEffect } from './hooks/use-deep-effect.ts';
+import { useEvent } from './hooks/use-event.ts';
 import { usePropertyChanged } from './hooks/use-property-changed.ts';
 import { useStateInitial, useStateRefInitial } from './hooks/use-state-initial.ts';
 import { useStateRef } from './hooks/use-state-ref.ts';
@@ -25,6 +26,7 @@ export {
   forceAssert,
   useDeepMemo,
   useDeepEffect,
+  useEvent,
   usePropertyChanged,
   useStateInitial,
   useStateRefInitial,


### PR DESCRIPTION
Created a `useEvent` hook that maintains a stable function without causing closures around any outside data.