### PR TITLE
BC-29 - On Error

### DIFF
--- a/src/custom-types/form-control.interface.ts
+++ b/src/custom-types/form-control.interface.ts
@@ -13,6 +13,7 @@ export interface FormInputControl<V = unknown, C = undefined> {
   onBlur?: (event: FocusEvent) => void;
   onInput?: (event: React.FormEvent) => void;
   onChange?: (value?: C extends undefined ? V : C) => void;
+  onError?: (errorValue?: V) => void;
   className?: string;
 }
 


### PR DESCRIPTION
Added an `onError` event to allow a component to tell the developer when an error has occurred.